### PR TITLE
fix zsh-autosuggestions clearing

### DIFF
--- a/minimal.zsh-theme
+++ b/minimal.zsh-theme
@@ -237,5 +237,6 @@ RPS1='$(mnml_wrap MNML_RPROMPT)'
 
 _mnml_bind_widgets
 
+ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=buffer-empty
 bindkey -M main "^M" buffer-empty
 bindkey -M vicmd "^M" buffer-empty


### PR DESCRIPTION
uses a fix suggested in https://github.com/zsh-users/zsh-autosuggestions/issues/162 to clear zsh autosuggestions on enter. i think this is worth adding since zsh-autosuggestions is installed by default w/, zim i think